### PR TITLE
ci: uninstall triton to fix segfault (exit 139) in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
           python -m site
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
+          # triton (a Linux-only torch dep) segfaults on import on the CI runner,
+          # crashing the whole test process. CPU-only testing never needs it.
+          python -m pip uninstall -y triton pytorch-triton || true
       - name: "Run pytest for ${{ matrix.python-version }}"
         run: "python -W ignore -m pytest tests"
 

--- a/.github/workflows/test_from_github.yml
+++ b/.github/workflows/test_from_github.yml
@@ -33,6 +33,10 @@ jobs:
           python -m pip install git+https://github.com/yasserfarouk/negmas.git
           yes | python -m pip uninstall scml
           python -m pip install git+https://github.com/yasserfarouk/scml.git
+          # triton (a Linux-only torch dep) segfaults on import on the CI runner,
+          # crashing the whole test process. CPU-only testing never needs it.
+          # Keep last so the scml/negmas reinstalls above can't drag it back in.
+          python -m pip uninstall -y triton pytorch-triton || true
       - name: "Run pytest for ${{ matrix.python-version }}"
         run: "python -W ignore -m pytest tests"
 


### PR DESCRIPTION
## Problem

CI was failing with exit code **139 (SIGSEGV)**. The crash happened in `tests/test_scml2023.py::test_can_run_oneshot` while instantiating `scml_agents/scml2023/oneshot/team_102`'s PPO RL agent.

Constructing `torch.optim.Adam` in newer torch triggers a `torch._dynamo` import → `import triton`. On the Linux GitHub runner, **triton segfaults on import**, aborting the entire pytest process (which also masked every test scheduled after it). On Linux the `torch>=2.2.0` wheel pulls triton in automatically; macOS doesn't, so it never reproduced locally.

## Fix

Uninstall the GPU-only `triton` after install in both CI workflows. CPU testing never uses it, and torch handles its absence gracefully (`has_triton_package()` returns `False`).

- `.github/workflows/test.yml`
- `.github/workflows/test_from_github.yml` (placed last so the scml/negmas git reinstalls can't drag triton back)

## Verification

Reproduced the exact post-fix condition locally (torch 2.10.0, triton absent, `GITHUB_ACTIONS=true`) and ran the full suite: **162 passed, 75 skipped, 0 failures**.